### PR TITLE
Add Romulus-M AEAD [ Nonce Misuse-Resistant ]

### DIFF
--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -30,5 +30,21 @@ BENCHMARK(bench_romulus::romulusn_decrypt)->Args({32, 2048});
 BENCHMARK(bench_romulus::romulusn_encrypt)->Args({32, 4096});
 BENCHMARK(bench_romulus::romulusn_decrypt)->Args({32, 4096});
 
+// register Romulus-M AEAD routines for benchmark
+BENCHMARK(bench_romulus::romulusm_encrypt)->Args({32, 64});
+BENCHMARK(bench_romulus::romulusm_decrypt)->Args({32, 64});
+BENCHMARK(bench_romulus::romulusm_encrypt)->Args({32, 128});
+BENCHMARK(bench_romulus::romulusm_decrypt)->Args({32, 128});
+BENCHMARK(bench_romulus::romulusm_encrypt)->Args({32, 256});
+BENCHMARK(bench_romulus::romulusm_decrypt)->Args({32, 256});
+BENCHMARK(bench_romulus::romulusm_encrypt)->Args({32, 512});
+BENCHMARK(bench_romulus::romulusm_decrypt)->Args({32, 512});
+BENCHMARK(bench_romulus::romulusm_encrypt)->Args({32, 1024});
+BENCHMARK(bench_romulus::romulusm_decrypt)->Args({32, 1024});
+BENCHMARK(bench_romulus::romulusm_encrypt)->Args({32, 2048});
+BENCHMARK(bench_romulus::romulusm_decrypt)->Args({32, 2048});
+BENCHMARK(bench_romulus::romulusm_encrypt)->Args({32, 4096});
+BENCHMARK(bench_romulus::romulusm_decrypt)->Args({32, 4096});
+
 // benchmark runner main function
 BENCHMARK_MAIN();

--- a/include/bench_aead.hpp
+++ b/include/bench_aead.hpp
@@ -3,6 +3,7 @@
 
 #include <cassert>
 
+#include "romulusm.hpp"
 #include "romulusn.hpp"
 #include "utils.hpp"
 
@@ -94,6 +95,115 @@ static void romulusn_decrypt(benchmark::State &state) {
   for (auto _ : state) {
     bool f = false;
     f = romulusn::decrypt(key, nonce, tag, data, dlen, enc, dec, ctlen);
+
+    benchmark::DoNotOptimize(f);
+    benchmark::DoNotOptimize(dec);
+    benchmark::ClobberMemory();
+  }
+
+  for (size_t i = 0; i < ctlen; i++) {
+    assert((txt[i] ^ dec[i]) == 0);
+  }
+
+  const size_t per_itr_data = dlen + ctlen;
+  const size_t total_data = per_itr_data * state.iterations();
+
+  state.SetBytesProcessed(static_cast<int64_t>(total_data));
+
+  std::free(key);
+  std::free(nonce);
+  std::free(tag);
+  std::free(data);
+  std::free(txt);
+  std::free(enc);
+  std::free(dec);
+}
+
+// Benchmarks Romulus-M authenticated encryption routine on CPU, with variable
+// length associated data and plain text bytes
+static void romulusm_encrypt(benchmark::State &state) {
+  constexpr size_t kntlen = 16;
+
+  const size_t dlen = state.range(0);
+  const size_t ctlen = state.range(1);
+
+  uint8_t *key = static_cast<uint8_t *>(std::malloc(kntlen));
+  uint8_t *nonce = static_cast<uint8_t *>(std::malloc(kntlen));
+  uint8_t *tag = static_cast<uint8_t *>(std::malloc(kntlen));
+  uint8_t *data = static_cast<uint8_t *>(std::malloc(dlen));
+  uint8_t *txt = static_cast<uint8_t *>(std::malloc(ctlen));
+  uint8_t *enc = static_cast<uint8_t *>(std::malloc(ctlen));
+  uint8_t *dec = static_cast<uint8_t *>(std::malloc(ctlen));
+
+  random_data(key, kntlen);
+  random_data(nonce, kntlen);
+  random_data(data, dlen);
+  random_data(txt, ctlen);
+
+  std::memset(tag, 0, kntlen);
+  std::memset(enc, 0, ctlen);
+  std::memset(dec, 0, ctlen);
+
+  for (auto _ : state) {
+    romulusm::encrypt(key, nonce, data, dlen, txt, enc, ctlen, tag);
+
+    benchmark::DoNotOptimize(enc);
+    benchmark::DoNotOptimize(tag);
+    benchmark::ClobberMemory();
+  }
+
+  bool f = false;
+  f = romulusm::decrypt(key, nonce, tag, data, dlen, enc, dec, ctlen);
+  assert(f);
+
+  for (size_t i = 0; i < ctlen; i++) {
+    assert((txt[i] ^ dec[i]) == 0);
+  }
+
+  const size_t per_itr_data = dlen + ctlen;
+  const size_t total_data = per_itr_data * state.iterations();
+
+  state.SetBytesProcessed(static_cast<int64_t>(total_data));
+
+  std::free(key);
+  std::free(nonce);
+  std::free(tag);
+  std::free(data);
+  std::free(txt);
+  std::free(enc);
+  std::free(dec);
+}
+
+// Benchmarks Romulus-M verified decryption routine on CPU, with variable
+// length associated data and plain/ cipher text bytes
+static void romulusm_decrypt(benchmark::State &state) {
+  constexpr size_t kntlen = 16;
+
+  const size_t dlen = state.range(0);
+  const size_t ctlen = state.range(1);
+
+  uint8_t *key = static_cast<uint8_t *>(std::malloc(kntlen));
+  uint8_t *nonce = static_cast<uint8_t *>(std::malloc(kntlen));
+  uint8_t *tag = static_cast<uint8_t *>(std::malloc(kntlen));
+  uint8_t *data = static_cast<uint8_t *>(std::malloc(dlen));
+  uint8_t *txt = static_cast<uint8_t *>(std::malloc(ctlen));
+  uint8_t *enc = static_cast<uint8_t *>(std::malloc(ctlen));
+  uint8_t *dec = static_cast<uint8_t *>(std::malloc(ctlen));
+
+  random_data(key, kntlen);
+  random_data(nonce, kntlen);
+  random_data(data, dlen);
+  random_data(txt, ctlen);
+
+  std::memset(tag, 0, kntlen);
+  std::memset(enc, 0, ctlen);
+  std::memset(dec, 0, ctlen);
+
+  romulusm::encrypt(key, nonce, data, dlen, txt, enc, ctlen, tag);
+
+  for (auto _ : state) {
+    bool f = false;
+    f = romulusm::decrypt(key, nonce, tag, data, dlen, enc, dec, ctlen);
 
     benchmark::DoNotOptimize(f);
     benchmark::DoNotOptimize(dec);

--- a/include/bench_aead.hpp
+++ b/include/bench_aead.hpp
@@ -3,7 +3,7 @@
 
 #include <cassert>
 
-#include "aead.hpp"
+#include "romulusn.hpp"
 #include "utils.hpp"
 
 // Benchmark Romulus AEAD/ Hash routines on CPU
@@ -35,7 +35,7 @@ static void romulusn_encrypt(benchmark::State &state) {
   std::memset(dec, 0, ctlen);
 
   for (auto _ : state) {
-    romulus::encrypt_romulusn(key, nonce, data, dlen, txt, enc, ctlen, tag);
+    romulusn::encrypt(key, nonce, data, dlen, txt, enc, ctlen, tag);
 
     benchmark::DoNotOptimize(enc);
     benchmark::DoNotOptimize(tag);
@@ -43,7 +43,7 @@ static void romulusn_encrypt(benchmark::State &state) {
   }
 
   bool f = false;
-  f = romulus::decrypt_romulusn(key, nonce, tag, data, dlen, enc, dec, ctlen);
+  f = romulusn::decrypt(key, nonce, tag, data, dlen, enc, dec, ctlen);
   assert(f);
 
   for (size_t i = 0; i < ctlen; i++) {
@@ -89,11 +89,11 @@ static void romulusn_decrypt(benchmark::State &state) {
   std::memset(enc, 0, ctlen);
   std::memset(dec, 0, ctlen);
 
-  romulus::encrypt_romulusn(key, nonce, data, dlen, txt, enc, ctlen, tag);
+  romulusn::encrypt(key, nonce, data, dlen, txt, enc, ctlen, tag);
 
   for (auto _ : state) {
     bool f = false;
-    f = romulus::decrypt_romulusn(key, nonce, tag, data, dlen, enc, dec, ctlen);
+    f = romulusn::decrypt(key, nonce, tag, data, dlen, enc, dec, ctlen);
 
     benchmark::DoNotOptimize(f);
     benchmark::DoNotOptimize(dec);

--- a/include/bench_hash.hpp
+++ b/include/bench_hash.hpp
@@ -1,7 +1,7 @@
 #pragma once
 #include <benchmark/benchmark.h>
 
-#include "hash.hpp"
+#include "romulush.hpp"
 #include "utils.hpp"
 
 // Benchmark Romulus AEAD/ Hash routines on CPU
@@ -19,7 +19,7 @@ static void romulush(benchmark::State& state) {
   random_data(msg, mlen);
 
   for (auto _ : state) {
-    romulus::hash(msg, mlen, dig);
+    romulush::hash(msg, mlen, dig);
 
     benchmark::DoNotOptimize(dig);
     benchmark::ClobberMemory();

--- a/include/romulush.hpp
+++ b/include/romulush.hpp
@@ -1,8 +1,8 @@
 #pragma once
 #include "skinny.hpp"
 
-// Romulus Authenticated Encryption and Hash Function
-namespace romulus {
+// Romulus Hash Function
+namespace romulush {
 
 // 32 -bytes input message compression function, used in Romulus-H hash
 // function, where message is consumed into two 128 -bit states ( i.e. denoted
@@ -81,4 +81,4 @@ inline static void hash(
   std::memcpy(dig + 16, right, 16);
 }
 
-}  // namespace romulus
+}  // namespace romulush

--- a/include/romulusm.hpp
+++ b/include/romulusm.hpp
@@ -1,0 +1,48 @@
+#pragma once
+#include <algorithm>
+
+#include "common.hpp"
+#include "skinny.hpp"
+
+// Romulus Authenticated Encryption and Hash Function
+namespace romulus {
+
+// Extract N-th message block ( 128 -bit wide ) from concatenated padded
+// associated data bytes and padded plain text bytes. Last block of both
+// associated data and plain text can be padded, if required.
+static void get_auth_block(
+    const uint8_t* const __restrict data,  // N -bytes associated data
+    const size_t dlen,                     // len(data) = N | >= 0
+    const uint8_t* const __restrict text,  // M -bytes plain text
+    const size_t ctlen,                    // len(text) = M | >= 0
+    const size_t blk_idx,                  // Index of block to extract
+    uint8_t* const __restrict blk          // 16 -bytes extracted (padded) block
+) {
+  std::memset(blk, 0, 16);
+
+  const size_t off = blk_idx << 4;
+  const size_t padded_dlen = dlen + (16ul - (dlen & 15ul));
+  const size_t padded_ctlen = ctlen + (16ul - (ctlen & 15ul));
+  const size_t padded_authlen = padded_dlen + padded_ctlen;
+
+  if (off < padded_dlen) {
+    const size_t read = std::min(16ul, dlen - off);
+
+    std::memcpy(blk, data + off, read);
+
+    const uint8_t br[]{blk[15], read};
+    blk[15] = br[read < 16ul];
+  }
+
+  if ((off >= padded_dlen) && (off < padded_authlen)) {
+    const size_t ctoff = off - padded_dlen;
+    const size_t read = std::min(16ul, ctlen - ctoff);
+
+    std::memcpy(blk, text + ctoff, read);
+
+    const uint8_t br[]{blk[15], read};
+    blk[15] = br[read < 16ul];
+  }
+}
+
+}  // namespace romulus

--- a/include/romulusm.hpp
+++ b/include/romulusm.hpp
@@ -4,8 +4,8 @@
 #include "common.hpp"
 #include "skinny.hpp"
 
-// Romulus Authenticated Encryption and Hash Function
-namespace romulus {
+// Romulus-M Authenticated Encryption with Associated Data
+namespace romulusm {
 
 // Extract N-th message block ( 128 -bit wide ) from concatenated padded
 // associated data bytes and padded plain text bytes. Last block of both
@@ -52,7 +52,7 @@ static void get_auth_block(
 //
 // See encryption algorithm defined in figure 2.7 of Romulus specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/romulus-spec-final.pdf
-static void encrypt_romulusm(
+static void encrypt(
     const uint8_t* const __restrict key,    // 128 -bit secret key
     const uint8_t* const __restrict nonce,  // 128 -bit public message nonce
     const uint8_t* const __restrict data,   // N -bytes associated data
@@ -203,7 +203,7 @@ static void encrypt_romulusm(
 //
 // See decryption algorithm defined in figure 2.7 of Romulus specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/romulus-spec-final.pdf
-static bool decrypt_romulusm(
+static bool decrypt(
     const uint8_t* const __restrict key,     // 128 -bit secret key
     const uint8_t* const __restrict nonce,   // 128 -bit public message nonce
     const uint8_t* const __restrict tag,     // 128 -bit authentication tag
@@ -358,4 +358,4 @@ static bool decrypt_romulusm(
   return !flg;
 }
 
-}  // namespace romulus
+}  // namespace romulusm

--- a/include/romulusm.hpp
+++ b/include/romulusm.hpp
@@ -20,9 +20,17 @@ static void get_auth_block(
 ) {
   std::memset(blk, 0, 16);
 
+  const size_t tmp0 = dlen & 15ul;
+  const size_t tmp1 = ctlen & 15ul;
+
+  const bool flg0 = (dlen == 0) | (tmp0 > 0ul);
+  const bool flg1 = (ctlen == 0) | (tmp1 > 0ul);
+
   const size_t off = blk_idx << 4;
-  const size_t padded_dlen = dlen + (16ul - (dlen & 15ul));
-  const size_t padded_ctlen = ctlen + (16ul - (ctlen & 15ul));
+
+  const size_t padded_dlen = dlen + (16ul - tmp0) * flg0;
+  const size_t padded_ctlen = ctlen + (16ul - tmp1) * flg1;
+
   const size_t padded_authlen = padded_dlen + padded_ctlen;
 
   if (off < padded_dlen) {
@@ -88,8 +96,8 @@ static void encrypt(
 
     uint8_t w = 48;
 
-    w ^= 2 * (ad_rm_bytes < 16ul);
-    w ^= 1 * (ct_rm_bytes < 16ul);
+    w ^= 2 * flg0;
+    w ^= 1 * flg1;
     w ^= 8 * (1 - (tot_ad_blk_cnt & 1));
     w ^= 4 * (1 - (tot_ct_blk_cnt & 1));
 
@@ -287,8 +295,8 @@ static bool decrypt(
 
     uint8_t w = 48;
 
-    w ^= 2 * (ad_rm_bytes < 16ul);
-    w ^= 1 * (ct_rm_bytes < 16ul);
+    w ^= 2 * flg0;
+    w ^= 1 * flg1;
     w ^= 8 * (1 - (tot_ad_blk_cnt & 1));
     w ^= 4 * (1 - (tot_ct_blk_cnt & 1));
 

--- a/include/romulusm.hpp
+++ b/include/romulusm.hpp
@@ -196,4 +196,166 @@ static void encrypt_romulusm(
   }
 }
 
+// Given 16 -bytes secret key, 16 -bytes nonce, 16 -bytes authentication tag, N
+// -bytes associated data and M -bytes encrypted text | N, M >= 0, this routine
+// computes M -bytes decrypted text and boolean verification flag, using
+// Romulus-M verified decryption algorithm, which is nonce misuse-resistant.
+//
+// See decryption algorithm defined in figure 2.7 of Romulus specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/romulus-spec-final.pdf
+static bool decrypt_romulusm(
+    const uint8_t* const __restrict key,     // 128 -bit secret key
+    const uint8_t* const __restrict nonce,   // 128 -bit public message nonce
+    const uint8_t* const __restrict tag,     // 128 -bit authentication tag
+    const uint8_t* const __restrict data,    // N -bytes associated data
+    const size_t dlen,                       // len(data) = N | >= 0
+    const uint8_t* const __restrict cipher,  // M -bytes encrypted text
+    uint8_t* const __restrict text,          // M -bytes decrypted text
+    const size_t ctlen                       // len(text) = len(cipher) | >= 0
+) {
+  uint8_t state[16];
+  uint8_t lfsr[7];
+
+  uint8_t enc[16];
+  uint8_t tweakey[48];
+
+  skinny::state st;
+
+  if (ctlen > 0ul) {
+    romulus_common::set_lfsr(lfsr);
+
+    std::memcpy(state, tag, 16);
+
+    const size_t blk_cnt = ctlen >> 4;
+    const size_t rm_bytes = ctlen & 15ul;
+
+    const bool flg = (ctlen == 0) | (rm_bytes > 0);
+    const size_t tot_blk_cnt = blk_cnt + 1ul * flg;
+
+    size_t off = 0ul;
+
+    for (size_t i = 0; i < tot_blk_cnt - 1; i++) {
+      romulus_common::encode(key, nonce, lfsr, 36, tweakey);
+
+      skinny::initialize(&st, state, tweakey);
+      skinny::tbc(&st);
+
+      std::memcpy(state, st.is, 16);
+
+      romulus_common::rho_inv(state, cipher + off, text + off);
+      romulus_common::update_lfsr(lfsr);
+
+      off += 16;
+    }
+
+    const size_t read = ctlen - off;
+
+    uint8_t blk[16]{};
+
+    std::memset(blk, 0, 16);
+    std::memcpy(blk, cipher + off, read);
+
+    const uint8_t br[]{blk[15], static_cast<uint8_t>(read)};
+    blk[15] = br[read < 16ul];
+
+    romulus_common::encode(key, nonce, lfsr, 36, tweakey);
+
+    skinny::initialize(&st, state, tweakey);
+    skinny::tbc(&st);
+
+    std::memcpy(state, st.is, 16);
+
+    romulus_common::rho_inv(state, blk, enc);
+    std::memcpy(text + off, enc, read);
+  }
+
+  {
+    std::memset(state, 0, 16);
+    romulus_common::set_lfsr(lfsr);
+
+    const size_t ad_blk_cnt = dlen >> 4;
+    const size_t ct_blk_cnt = ctlen >> 4;
+
+    const size_t ad_rm_bytes = dlen & 15ul;
+    const size_t ct_rm_bytes = ctlen & 15ul;
+
+    const bool flg0 = (dlen == 0) | (ad_rm_bytes > 0);
+    const bool flg1 = (ctlen == 0) | (ct_rm_bytes > 0);
+
+    const size_t tot_ad_blk_cnt = ad_blk_cnt + 1ul * flg0;
+    const size_t tot_ct_blk_cnt = ct_blk_cnt + 1ul * flg1;
+
+    uint8_t w = 48;
+
+    w ^= 2 * (ad_rm_bytes < 16ul);
+    w ^= 1 * (ct_rm_bytes < 16ul);
+    w ^= 8 * (1 - (tot_ad_blk_cnt & 1));
+    w ^= 4 * (1 - (tot_ct_blk_cnt & 1));
+
+    const size_t tot_blk_cnt = tot_ad_blk_cnt + tot_ct_blk_cnt;
+    const size_t half_blk_cnt = tot_blk_cnt >> 1;
+    const size_t half_ad_blk_cnt = tot_ad_blk_cnt >> 1;
+
+    uint8_t blk[16]{};
+    uint8_t x = 40;
+
+    for (size_t i = 0; i < half_blk_cnt; i++) {
+      get_auth_block(data, dlen, text, ctlen, (i << 1) ^ 0ul, blk);
+
+      romulus_common::rho(state, blk, enc);
+      romulus_common::update_lfsr(lfsr);
+
+      x ^= 4 * (i == half_ad_blk_cnt);
+
+      get_auth_block(data, dlen, text, ctlen, (i << 1) ^ 1ul, blk);
+      romulus_common::encode(key, blk, lfsr, x, tweakey);
+
+      skinny::initialize(&st, state, tweakey);
+      skinny::tbc(&st);
+
+      std::memcpy(state, st.is, 16);
+
+      romulus_common::update_lfsr(lfsr);
+    }
+
+    const bool flg2 = static_cast<bool>(tot_ad_blk_cnt & 1ul);
+    const bool flg3 = static_cast<bool>(tot_ct_blk_cnt & 1ul);
+
+    if (flg2 == flg3) {
+      std::memset(blk, 0, 16);
+    } else {
+      get_auth_block(data, dlen, text, ctlen, tot_blk_cnt - 1, blk);
+    }
+
+    romulus_common::rho(state, blk, enc);
+
+    if (tot_blk_cnt > (half_blk_cnt << 1)) {
+      romulus_common::update_lfsr(lfsr);
+    }
+
+    romulus_common::encode(key, nonce, lfsr, w, tweakey);
+
+    skinny::initialize(&st, state, tweakey);
+    skinny::tbc(&st);
+
+    std::memcpy(state, st.is, 16);
+  }
+
+  uint8_t tmp[16]{};
+  uint8_t tag_[16]{};
+
+  std::memset(tmp, 0, 16);
+  std::memset(tag_, 0, 16);
+
+  romulus_common::rho(state, tmp, tag_);
+
+  bool flg = false;
+  for (size_t i = 0; i < 16; i++) {
+    flg |= static_cast<bool>(tag[i] ^ tag_[i]);
+  }
+
+  std::memset(text, 0, flg * ctlen);
+  return !flg;
+}
+
 }  // namespace romulus

--- a/include/romulusm.hpp
+++ b/include/romulusm.hpp
@@ -30,7 +30,7 @@ static void get_auth_block(
 
     std::memcpy(blk, data + off, read);
 
-    const uint8_t br[]{blk[15], read};
+    const uint8_t br[]{blk[15], static_cast<uint8_t>(read)};
     blk[15] = br[read < 16ul];
   }
 
@@ -40,8 +40,159 @@ static void get_auth_block(
 
     std::memcpy(blk, text + ctoff, read);
 
-    const uint8_t br[]{blk[15], read};
+    const uint8_t br[]{blk[15], static_cast<uint8_t>(read)};
     blk[15] = br[read < 16ul];
+  }
+}
+
+// Given 16 -bytes secret key, 16 -bytes nonce, N -bytes associated data and M
+// -bytes plain text | N, M >= 0, this routine computes M -bytes encrypted text
+// and 16 -bytes authentication tag, using Romulus-M authenticated encryption
+// algorithm, which is nonce misuse-resistant.
+//
+// See encryption algorithm defined in figure 2.7 of Romulus specification
+// https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/romulus-spec-final.pdf
+static void encrypt_romulusm(
+    const uint8_t* const __restrict key,    // 128 -bit secret key
+    const uint8_t* const __restrict nonce,  // 128 -bit public message nonce
+    const uint8_t* const __restrict data,   // N -bytes associated data
+    const size_t dlen,                      // len(data) = N | >= 0
+    const uint8_t* const __restrict text,   // M -bytes plain text
+    uint8_t* const __restrict cipher,       // M -bytes encrypted text
+    const size_t ctlen,                     // len(text) = len(cipher) | >= 0
+    uint8_t* const __restrict tag           // 128 -bit authentication tag
+) {
+  uint8_t state[16];
+  uint8_t lfsr[7];
+
+  uint8_t enc[16];
+  uint8_t tweakey[48];
+
+  skinny::state st;
+
+  std::memset(state, 0, 16);
+  romulus_common::set_lfsr(lfsr);
+
+  {
+    const size_t ad_blk_cnt = dlen >> 4;
+    const size_t ct_blk_cnt = ctlen >> 4;
+
+    const size_t ad_rm_bytes = dlen & 15ul;
+    const size_t ct_rm_bytes = ctlen & 15ul;
+
+    const bool flg0 = (dlen == 0) | (ad_rm_bytes > 0);
+    const bool flg1 = (ctlen == 0) | (ct_rm_bytes > 0);
+
+    const size_t tot_ad_blk_cnt = ad_blk_cnt + 1ul * flg0;
+    const size_t tot_ct_blk_cnt = ct_blk_cnt + 1ul * flg1;
+
+    uint8_t w = 48;
+
+    w ^= 2 * (ad_rm_bytes < 16ul);
+    w ^= 1 * (ct_rm_bytes < 16ul);
+    w ^= 8 * (1 - (tot_ad_blk_cnt & 1));
+    w ^= 4 * (1 - (tot_ct_blk_cnt & 1));
+
+    const size_t tot_blk_cnt = tot_ad_blk_cnt + tot_ct_blk_cnt;
+    const size_t half_blk_cnt = tot_blk_cnt >> 1;
+    const size_t half_ad_blk_cnt = tot_ad_blk_cnt >> 1;
+
+    uint8_t blk[16]{};
+    uint8_t x = 40;
+
+    for (size_t i = 0; i < half_blk_cnt; i++) {
+      get_auth_block(data, dlen, text, ctlen, (i << 1) ^ 0ul, blk);
+
+      romulus_common::rho(state, blk, enc);
+      romulus_common::update_lfsr(lfsr);
+
+      x ^= 4 * (i == half_ad_blk_cnt);
+
+      get_auth_block(data, dlen, text, ctlen, (i << 1) ^ 1ul, blk);
+      romulus_common::encode(key, blk, lfsr, x, tweakey);
+
+      skinny::initialize(&st, state, tweakey);
+      skinny::tbc(&st);
+
+      std::memcpy(state, st.is, 16);
+
+      romulus_common::update_lfsr(lfsr);
+    }
+
+    const bool flg2 = static_cast<bool>(tot_ad_blk_cnt & 1ul);
+    const bool flg3 = static_cast<bool>(tot_ct_blk_cnt & 1ul);
+
+    if (flg2 == flg3) {
+      std::memset(blk, 0, 16);
+    } else {
+      get_auth_block(data, dlen, text, ctlen, tot_blk_cnt - 1, blk);
+    }
+
+    romulus_common::rho(state, blk, enc);
+
+    if (tot_blk_cnt > (half_blk_cnt << 1)) {
+      romulus_common::update_lfsr(lfsr);
+    }
+
+    romulus_common::encode(key, nonce, lfsr, w, tweakey);
+
+    skinny::initialize(&st, state, tweakey);
+    skinny::tbc(&st);
+
+    std::memcpy(state, st.is, 16);
+  }
+
+  uint8_t tmp[16]{};
+  std::memset(tmp, 0, 16);
+
+  romulus_common::rho(state, tmp, tag);
+
+  if (ctlen > 0ul) {
+    romulus_common::set_lfsr(lfsr);
+
+    std::memcpy(state, tag, 16);
+
+    const size_t blk_cnt = ctlen >> 4;
+    const size_t rm_bytes = ctlen & 15ul;
+
+    const bool flg = (ctlen == 0) | (rm_bytes > 0);
+    const size_t tot_blk_cnt = blk_cnt + 1ul * flg;
+
+    size_t off = 0ul;
+
+    for (size_t i = 0; i < tot_blk_cnt - 1; i++) {
+      romulus_common::encode(key, nonce, lfsr, 36, tweakey);
+
+      skinny::initialize(&st, state, tweakey);
+      skinny::tbc(&st);
+
+      std::memcpy(state, st.is, 16);
+
+      romulus_common::rho(state, text + off, cipher + off);
+      romulus_common::update_lfsr(lfsr);
+
+      off += 16;
+    }
+
+    const size_t read = ctlen - off;
+
+    uint8_t blk[16]{};
+
+    std::memset(blk, 0, 16);
+    std::memcpy(blk, text + off, read);
+
+    const uint8_t br[]{blk[15], static_cast<uint8_t>(read)};
+    blk[15] = br[read < 16ul];
+
+    romulus_common::encode(key, nonce, lfsr, 36, tweakey);
+
+    skinny::initialize(&st, state, tweakey);
+    skinny::tbc(&st);
+
+    std::memcpy(state, st.is, 16);
+
+    romulus_common::rho(state, blk, enc);
+    std::memcpy(cipher + off, enc, read);
   }
 }
 

--- a/include/romulusn.hpp
+++ b/include/romulusn.hpp
@@ -4,8 +4,8 @@
 #include "common.hpp"
 #include "skinny.hpp"
 
-// Romulus Authenticated Encryption and Hash Function
-namespace romulus {
+// Romulus-N Authenticated Encryption with Associated Data
+namespace romulusn {
 
 // Given 16 -bytes secret key, 16 -bytes nonce, N -bytes associated data and M
 // -bytes plain text | N, M >= 0, this routine computes M -bytes encrypted text
@@ -14,7 +14,7 @@ namespace romulus {
 //
 // See encryption algorithm defined in figure 2.5 of Romulus specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/romulus-spec-final.pdf
-inline static void encrypt_romulusn(
+inline static void encrypt(
     const uint8_t* const __restrict key,    // 128 -bit secret key
     const uint8_t* const __restrict nonce,  // 128 -bit public message nonce
     const uint8_t* const __restrict data,   // N -bytes associated data
@@ -164,7 +164,7 @@ inline static void encrypt_romulusn(
 //
 // See decryption algorithm defined in figure 2.5 of Romulus specification
 // https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-spec-doc/romulus-spec-final.pdf
-inline static bool decrypt_romulusn(
+inline static bool decrypt(
     const uint8_t* const __restrict key,     // 128 -bit secret key
     const uint8_t* const __restrict nonce,   // 128 -bit public message nonce
     const uint8_t* const __restrict tag,     // 128 -bit authentication tag
@@ -335,4 +335,4 @@ inline static bool decrypt_romulusn(
   return !flg;
 }
 
-}  // namespace romulus
+}  // namespace romulusn

--- a/include/romulusn.hpp
+++ b/include/romulusn.hpp
@@ -332,6 +332,7 @@ inline static bool decrypt(
     flg |= static_cast<bool>(tag[i] ^ tag_[i]);
   }
 
+  std::memset(txt, 0, flg * ctlen);
   return !flg;
 }
 

--- a/test_kat.sh
+++ b/test_kat.sh
@@ -12,22 +12,34 @@ pushd tmp
 wget -O romulus.zip https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-submissions/romulus.zip
 unzip romulus.zip
 
-cp romulus/Implementations/crypto_aead/romulush/LWC_HASH_KAT_256.txt ../
-cp romulus/Implementations/crypto_aead/romulusn/LWC_AEAD_KAT_128_128.txt ../
+cp romulus/Implementations/crypto_aead/romulush/LWC_HASH_KAT_256.txt ../romulush.txt
+cp romulus/Implementations/crypto_aead/romulusn/LWC_AEAD_KAT_128_128.txt ../romulusn.txt
+cp romulus/Implementations/crypto_aead/romulusm/LWC_AEAD_KAT_128_128.txt ../romulusm.txt
+cp romulus/Implementations/crypto_aead/romulust/LWC_AEAD_KAT_128_128.txt ../romulust.txt
 
 popd
 
 # ---
 
 rm -rf tmp
-mv LWC_HASH_KAT_256.txt wrapper/python/
-mv LWC_AEAD_KAT_128_128.txt wrapper/python/
+mv romulus{h,n,m,t}.txt wrapper/python/
 
 # ---
 
 pushd wrapper/python
 
-python3 -m pytest -v
+mv romulush.txt LWC_HASH_KAT_256.txt
+python3 -m pytest -k romulush -v
+
+mv romulusn.txt LWC_AEAD_KAT_128_128.txt
+python3 -m pytest -k romulusn -v
+
+mv romulusm.txt LWC_AEAD_KAT_128_128.txt
+python3 -m pytest -k romulusm -v
+
+mv romulust.txt LWC_AEAD_KAT_128_128.txt
+python3 -m pytest -k romulust -v
+
 rm LWC_*_KAT_*.txt
 
 popd

--- a/wrapper/python/romulus.py
+++ b/wrapper/python/romulus.py
@@ -114,5 +114,74 @@ def romulusn_decrypt(
     return f, dec_
 
 
+def romulusm_encrypt(
+    key: bytes, nonce: bytes, data: bytes, text: bytes
+) -> Tuple[bytes, bytes]:
+    """
+    Encrypts M ( >=0 ) -bytes plain text, with Romulus-M AEAD,
+    while using 16 -bytes secret key, 16 -bytes public message nonce &
+    N ( >=0 ) -bytes associated data, while producing M -bytes cipher text
+    & 16 -bytes authentication tag ( in order )
+    """
+    assert len(key) == 16, "Romulus-M takes 16 -bytes secret key !"
+    assert len(nonce) == 16, "Romulus-M takes 16 -bytes nonce !"
+
+    ad_len = len(data)
+    ct_len = len(text)
+
+    key_ = np.frombuffer(key, dtype=u8)
+    nonce_ = np.frombuffer(nonce, dtype=u8)
+    data_ = np.frombuffer(data, dtype=u8)
+    text_ = np.frombuffer(text, dtype=u8)
+    enc = np.empty(ct_len, dtype=u8)
+    tag = np.empty(16, dtype=u8)
+
+    args = [uint8_tp, uint8_tp, uint8_tp, len_t, uint8_tp, uint8_tp, len_t, uint8_tp]
+    SO_LIB.romulusm_encrypt.argtypes = args
+
+    SO_LIB.romulusm_encrypt(key_, nonce_, data_, ad_len, text_, enc, ct_len, tag)
+
+    enc_ = enc.tobytes()
+    tag_ = tag.tobytes()
+
+    return enc_, tag_
+
+
+def romulusm_decrypt(
+    key: bytes, nonce: bytes, tag: bytes, data: bytes, enc: bytes
+) -> Tuple[bool, bytes]:
+    """
+    Decrypts M ( >=0 ) -bytes cipher text, with Romulus-M AEAD,
+    while using 16 -bytes secret key, 16 -bytes public message nonce,
+    16 -bytes authentication tag & N ( >=0 ) -bytes associated data, while
+    producing boolean flag denoting verification status ( which must hold truth
+    value, check before consuming decrypted output bytes ) & M -bytes
+    plain text ( in order )
+    """
+    assert len(key) == 16, "Romulus-M takes 16 -bytes secret key !"
+    assert len(nonce) == 16, "Romulus-M takes 16 -bytes nonce !"
+    assert len(tag) == 16, "Romulus-M takes 16 -bytes authentication tag !"
+
+    ad_len = len(data)
+    ct_len = len(enc)
+
+    key_ = np.frombuffer(key, dtype=u8)
+    nonce_ = np.frombuffer(nonce, dtype=u8)
+    tag_ = np.frombuffer(tag, dtype=u8)
+    data_ = np.frombuffer(data, dtype=u8)
+    enc_ = np.frombuffer(enc, dtype=u8)
+    dec = np.empty(ct_len, dtype=u8)
+
+    args = [uint8_tp, uint8_tp, uint8_tp, uint8_tp, len_t, uint8_tp, uint8_tp, len_t]
+    SO_LIB.romulusm_decrypt.argtypes = args
+    SO_LIB.romulusm_decrypt.restype = bool_t
+
+    f = SO_LIB.romulusm_decrypt(key_, nonce_, tag_, data_, ad_len, enc_, dec, ct_len)
+
+    dec_ = dec.tobytes()
+
+    return f, dec_
+
+
 if __name__ == "__main__":
     print("Use `romulus` as library module")

--- a/wrapper/python/romulus.py
+++ b/wrapper/python/romulus.py
@@ -37,9 +37,9 @@ def romulush(msg: bytes) -> bytes:
     digest = np.empty(32, dtype=u8)
 
     args = [uint8_tp, len_t, uint8_tp]
-    SO_LIB.romulush.argtypes = args
+    SO_LIB.romulus_hash.argtypes = args
 
-    SO_LIB.romulush(msg_, m_len, digest)
+    SO_LIB.romulus_hash(msg_, m_len, digest)
 
     digest_ = digest.tobytes()
     return digest_

--- a/wrapper/python/test_romulus.py
+++ b/wrapper/python/test_romulus.py
@@ -81,7 +81,7 @@ def test_romulusn_kat():
 
             # 128 -bit secret key
             key = int(f"0x{key}", base=16).to_bytes(16, "big")
-            # 256 -bit public message nonce
+            # 128 -bit public message nonce
             nonce = int(f"0x{nonce}", base=16).to_bytes(16, "big")
             # plain text
             pt = bytes(
@@ -110,10 +110,79 @@ def test_romulusn_kat():
 
             assert (
                 cipher + tag == ct
-            ), f"[Romulus-N KAT {cnt}] expected cipher to be 0x{ct.hex()}, found 0x${(cipher + tag).hex()} !"
+            ), f"[Romulus-N KAT {cnt}] expected cipher to be 0x{ct.hex()}, found 0x{(cipher + tag).hex()} !"
             assert (
                 pt == text and flag
             ), f"[Romulus-N KAT {cnt}] expected plain text 0x{pt.hex()}, found 0x{text.hex()} !"
+
+            # don't need this line, so discard
+            fd.readline()
+
+
+def test_romulusm_kat():
+    """
+    Tests functional correctness of Romulus-M AEAD implementation, using
+    Known Answer Tests submitted along with final round submission of Romulus
+    in NIST LWC
+
+    See https://csrc.nist.gov/projects/lightweight-cryptography/finalists
+    """
+    with open("LWC_AEAD_KAT_128_128.txt", "r") as fd:
+        while True:
+            cnt = fd.readline()
+            if not cnt:
+                # no more KATs remaining
+                break
+
+            key = fd.readline()
+            nonce = fd.readline()
+            pt = fd.readline()
+            ad = fd.readline()
+            ct = fd.readline()
+
+            # extract out required fields
+            cnt = int([i.strip() for i in cnt.split("=")][-1])
+            key = [i.strip() for i in key.split("=")][-1]
+            nonce = [i.strip() for i in nonce.split("=")][-1]
+            pt = [i.strip() for i in pt.split("=")][-1]
+            ad = [i.strip() for i in ad.split("=")][-1]
+            ct = [i.strip() for i in ct.split("=")][-1]
+
+            # 128 -bit secret key
+            key = int(f"0x{key}", base=16).to_bytes(16, "big")
+            # 128 -bit public message nonce
+            nonce = int(f"0x{nonce}", base=16).to_bytes(16, "big")
+            # plain text
+            pt = bytes(
+                [
+                    int(f"0x{pt[(i << 1): ((i+1) << 1)]}", base=16)
+                    for i in range(len(pt) >> 1)
+                ]
+            )
+            # associated data
+            ad = bytes(
+                [
+                    int(f"0x{ad[(i << 1): ((i+1) << 1)]}", base=16)
+                    for i in range(len(ad) >> 1)
+                ]
+            )
+            # cipher text + authentication tag ( expected )
+            ct = bytes(
+                [
+                    int(f"0x{ct[(i << 1): ((i+1) << 1)]}", base=16)
+                    for i in range(len(ct) >> 1)
+                ]
+            )
+
+            cipher, tag = romulus.romulusm_encrypt(key, nonce, ad, pt)
+            flag, text = romulus.romulusm_decrypt(key, nonce, tag, ad, cipher)
+
+            assert (
+                cipher + tag == ct
+            ), f"[Romulus-M KAT {cnt}] expected cipher to be 0x{ct.hex()}, found 0x{(cipher + tag).hex()} !"
+            assert (
+                pt == text and flag
+            ), f"[Romulus-M KAT {cnt}] expected plain text 0x{pt.hex()}, found 0x{text.hex()} !"
 
             # don't need this line, so discard
             fd.readline()

--- a/wrapper/romulus.cpp
+++ b/wrapper/romulus.cpp
@@ -1,5 +1,5 @@
-#include "aead.hpp"
-#include "hash.hpp"
+#include "romulush.hpp"
+#include "romulusn.hpp"
 
 // Thin C wrapper on top of underlying C++ implementation of Romulus-N
 // authenticated encryption and Romulus-H hash function, which can be used for
@@ -9,9 +9,9 @@
 // Function prototype
 extern "C" {
 
-void romulush(const uint8_t* const __restrict,  // input message
-              const size_t,                     // input message byte length
-              uint8_t* const __restrict         // output digest
+void romulus_hash(const uint8_t* const __restrict,  // input message
+                  const size_t,                     // input message byte length
+                  uint8_t* const __restrict         // output digest
 );
 
 void romulusn_encrypt(
@@ -42,11 +42,12 @@ extern "C" {
 
 // Given N (>=0) -bytes input message, this routines computes 32 -bytes output
 // digest, using Romulus-H hashing algorithm
-void romulush(const uint8_t* const __restrict in,  // input message
-              const size_t ilen,                   // len(in) | >= 0
-              uint8_t* const __restrict out  // 32 -bytes digest, to be computed
+void romulus_hash(
+    const uint8_t* const __restrict in,  // input message
+    const size_t ilen,                   // len(in) | >= 0
+    uint8_t* const __restrict out        // 32 -bytes digest, to be computed
 ) {
-  romulus::hash(in, ilen, out);
+  romulush::hash(in, ilen, out);
 }
 
 void romulusn_encrypt(
@@ -59,7 +60,7 @@ void romulusn_encrypt(
     const size_t ctlen,  // byte length of plain/ encrypted text = M | >= 0
     uint8_t* const __restrict tag  // 128 -bit authentication tag
 ) {
-  romulus::encrypt_romulusn(key, nonce, data, dlen, txt, enc, ctlen, tag);
+  romulusn::encrypt(key, nonce, data, dlen, txt, enc, ctlen, tag);
 }
 
 bool romulusn_decrypt(
@@ -72,7 +73,7 @@ bool romulusn_decrypt(
     uint8_t* const __restrict txt,        // M -bytes decrypted text
     const size_t ctlen  // byte length of encrypted/ decrypted text = M | >= 0
 ) {
-  using namespace romulus;
-  return decrypt_romulusn(key, nonce, tag, data, dlen, enc, txt, ctlen);
+  using namespace romulusn;
+  return decrypt(key, nonce, tag, data, dlen, enc, txt, ctlen);
 }
 }

--- a/wrapper/romulus.cpp
+++ b/wrapper/romulus.cpp
@@ -1,4 +1,5 @@
 #include "romulush.hpp"
+#include "romulusm.hpp"
 #include "romulusn.hpp"
 
 // Thin C wrapper on top of underlying C++ implementation of Romulus-N
@@ -26,6 +27,28 @@ void romulusn_encrypt(
 );
 
 bool romulusn_decrypt(
+    const uint8_t* const __restrict,  // 128 -bit secret key
+    const uint8_t* const __restrict,  // 128 -bit nonce
+    const uint8_t* const __restrict,  // 128 -bit authentication tag
+    const uint8_t* const __restrict,  // N -bytes associated data
+    const size_t,  // byte length of associated data = N | >= 0
+    const uint8_t* const __restrict,  // M -bytes encrypted text
+    uint8_t* const __restrict,        // M -bytes decrypted text
+    const size_t  // byte length of encrypted/ decrypted text = M | >= 0
+);
+
+void romulusm_encrypt(
+    const uint8_t* const __restrict,  // 128 -bit secret key
+    const uint8_t* const __restrict,  // 128 -bit nonce
+    const uint8_t* const __restrict,  // N -bytes associated data
+    const size_t,  // byte length of associated data = N | >= 0
+    const uint8_t* const __restrict,  // M -bytes plain text
+    uint8_t* const __restrict,        // M -bytes encrypted text
+    const size_t,  // byte length of plain/ encrypted text = M | >= 0
+    uint8_t* const __restrict  // 128 -bit authentication tag
+);
+
+bool romulusm_decrypt(
     const uint8_t* const __restrict,  // 128 -bit secret key
     const uint8_t* const __restrict,  // 128 -bit nonce
     const uint8_t* const __restrict,  // 128 -bit authentication tag
@@ -74,6 +97,33 @@ bool romulusn_decrypt(
     const size_t ctlen  // byte length of encrypted/ decrypted text = M | >= 0
 ) {
   using namespace romulusn;
+  return decrypt(key, nonce, tag, data, dlen, enc, txt, ctlen);
+}
+
+void romulusm_encrypt(
+    const uint8_t* const __restrict key,    // 128 -bit secret key
+    const uint8_t* const __restrict nonce,  // 128 -bit nonce
+    const uint8_t* const __restrict data,   // N -bytes associated data
+    const size_t dlen,  // byte length of associated data = N | >= 0
+    const uint8_t* const __restrict txt,  // M -bytes plain text
+    uint8_t* const __restrict enc,        // M -bytes encrypted text
+    const size_t ctlen,  // byte length of plain/ encrypted text = M | >= 0
+    uint8_t* const __restrict tag  // 128 -bit authentication tag
+) {
+  romulusm::encrypt(key, nonce, data, dlen, txt, enc, ctlen, tag);
+}
+
+bool romulusm_decrypt(
+    const uint8_t* const __restrict key,    // 128 -bit secret key
+    const uint8_t* const __restrict nonce,  // 128 -bit nonce
+    const uint8_t* const __restrict tag,    // 128 -bit authentication tag
+    const uint8_t* const __restrict data,   // N -bytes associated data
+    const size_t dlen,  // byte length of associated data = N | >= 0
+    const uint8_t* const __restrict enc,  // M -bytes encrypted text
+    uint8_t* const __restrict txt,        // M -bytes decrypted text
+    const size_t ctlen  // byte length of encrypted/ decrypted text = M | >= 0
+) {
+  using namespace romulusm;
   return decrypt(key, nonce, tag, data, dlen, enc, txt, ctlen);
 }
 }


### PR DESCRIPTION
- [x] Adds support for Romulus-M authenticated encryption with associated data (AEAD)
- [x] Ensure functional correctness using Known Answer Tests submitted along with Romulus submission [package](https://csrc.nist.gov/CSRC/media/Projects/lightweight-cryptography/documents/finalist-round/updated-submissions/romulus.zip)
- [x] Benchmark Romulus-M encrypt/ decrypt routines on CPU systems
- [x] Update documentation to reflect latest changes 